### PR TITLE
Associations for Housing Repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'hanami',       '~> 1.0'
-gem 'hanami-model', '~> 1.0'
+
+# FIXME: Using develop branch to have access to belongs_to association.
+# This hack should be removed as soon as hanami-model version is bumped.
+# gem 'hanami-model', '~> 1.0'
+gem 'hanami-model', '~> 1.0', github: 'hanami/model', branch: 'develop'
 
 gem 'pg'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: git://github.com/hanami/model.git
+  revision: e4bbc0d19c76f8b7e43ac93ecdbc9d8b7571f95e
+  branch: develop
+  specs:
+    hanami-model (1.0.0)
+      concurrent-ruby (~> 1.0)
+      dry-types (~> 0.10)
+      hanami-utils (~> 1.0)
+      rom-repository (~> 1.3)
+      rom-sql (~> 1.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -72,12 +84,6 @@ GEM
       hanami-utils (~> 1.0)
       mail (~> 2.5)
       tilt (~> 2.0, >= 2.0.1)
-    hanami-model (1.0.0)
-      concurrent-ruby (~> 1.0)
-      dry-types (~> 0.9)
-      hanami-utils (~> 1.0)
-      rom-repository (~> 1.3)
-      rom-sql (~> 1.2)
     hanami-router (1.0.0)
       hanami-utils (~> 1.0)
       http_router (= 0.11.2)
@@ -145,7 +151,7 @@ GEM
     transproc (1.0.2)
     url_mount (0.2.1)
       rack
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -155,7 +161,7 @@ DEPENDENCIES
   capybara
   dotenv (~> 2.0)
   hanami (~> 1.0)
-  hanami-model (~> 1.0)
+  hanami-model (~> 1.0)!
   minitest
   pg
   pry
@@ -163,4 +169,4 @@ DEPENDENCIES
   shotgun
 
 BUNDLED WITH
-   1.15.0
+   1.14.6

--- a/lib/housing_list/repositories/housing_repository.rb
+++ b/lib/housing_list/repositories/housing_repository.rb
@@ -3,4 +3,18 @@ class HousingRepository < Hanami::Repository
     belongs_to :trip
     belongs_to :user
   end
+
+  def all_by_trip_with_user(trip_id)
+    wrap_user.where(trip_id: trip_id).as(Housing).to_a
+  end
+
+  def find_with_user(id)
+    wrap_user.by_pk(id).as(Housing).one
+  end
+
+  private
+
+  def wrap_user
+    relations[:housings].wrap(:user)
+  end
 end

--- a/lib/housing_list/repositories/housing_repository.rb
+++ b/lib/housing_list/repositories/housing_repository.rb
@@ -1,2 +1,6 @@
 class HousingRepository < Hanami::Repository
+  associations do
+    belongs_to :trip
+    belongs_to :user
+  end
 end

--- a/lib/monkey_patches/hanami_utils.rb
+++ b/lib/monkey_patches/hanami_utils.rb
@@ -1,0 +1,67 @@
+require 'hanami/utils/duplicable'
+require 'transproc'
+
+# HACK: Patching Hanami::Utils::Hash to add deep_symbolize method.
+# This hack should be removed as soon as hanami-utils version is bumped.
+
+# Deprecation warning
+patched_version = '1.0.0'
+
+if Hanami::Utils::VERSION != patched_version
+  ::Kernel.warn("WARNING: You are running hanami-utils version #{Hanami::Utils::VERSION}. The monkey patch located at #{__FILE__} only applies to #{patched_version}, so please remove it.")
+end
+
+module Hanami
+  module Utils
+    # Hash on steroids
+    # @since 0.1.0
+    class Hash
+      extend Transproc::Registry
+      import Transproc::HashTransformations
+
+      # Symbolize the given hash
+      #
+      # @param input [::Hash] the input
+      #
+      # @return [::Hash] the symbolized hash
+      #
+      # @since x.x.x
+      #
+      # @see .deep_symbolize
+      #
+      # @example Basic Usage
+      #   require 'hanami/utils/hash'
+      #
+      #   hash = Hanami::Utils::Hash.symbolize("foo" => "bar", "baz" => {"a" => 1})
+      #     # => {:foo=>"bar", :baz=>{"a"=>1}}
+      #
+      #   hash.class
+      #     # => Hash
+      def self.symbolize(input)
+        self[:symbolize_keys].call(input)
+      end
+
+      # Deep symbolize the given hash
+      #
+      # @param input [::Hash] the input
+      #
+      # @return [::Hash] the deep symbolized hash
+      #
+      # @since x.x.x
+      #
+      # @see .symbolize
+      #
+      # @example Basic Usage
+      #   require 'hanami/utils/hash'
+      #
+      #   hash = Hanami::Utils::Hash.deep_symbolize("foo" => "bar", "baz" => {"a" => 1})
+      #     # => {:foo=>"bar", :baz=>{a:=>1}}
+      #
+      #   hash.class
+      #     # => Hash
+      def self.deep_symbolize(input)
+        self[:deep_symbolize_keys].call(input)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Switch to develop branch for `hanami-model` gem.
- Add belongs to associations (trip and user) to Housing repository.
- Add queries to Housing repository.
  - Find a Housing with its related user
  - Get all housings by trip id with their related user

BTW Had to monkey patch for `Hanami::Utils::Hash` class that was missing deep_symbolize method.
