### PR TITLE
Fix iPad css styling

### DIFF
--- a/apps/web/assets/stylesheets/components/_housing-card.scss
+++ b/apps/web/assets/stylesheets/components/_housing-card.scss
@@ -1,3 +1,5 @@
+$housing-card-image-width: 230px;
+
 .housing-cards {
   @media (max-width: $screen-xs-max) {
     display: flex;
@@ -8,7 +10,7 @@
 
 .housing-card {
   display: flex;
-  margin-bottom: 1em;
+  margin-bottom: 1.5em;
 
   @media (max-width: $screen-xs-max) {
     flex-direction: column;
@@ -17,12 +19,15 @@
   }
 
   @media (min-width: $screen-sm-min) {
-    align-items: center;
-    min-height: 230px;
+    flex-wrap: wrap;
+    position: relative;
   }
 
   @media (min-width: $screen-md-min) {
-    align-items: flex-start;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    height: $housing-card-image-width;
   }
 
   .title {
@@ -38,12 +43,17 @@
     flex-grow: 1;
 
     @media (max-width: $screen-xs-max) {
-      width: 230px;
+      width: $housing-card-image-width;
       margin: 2em 2em 1em 2em;
     }
 
     @media (min-width: $screen-sm-min) {
-      margin: 2em;
+      margin-left: 2em;
+      width: 50%;
+    }
+
+    @media (min-width: $screen-md-min) {
+      padding-bottom: 1em;
     }
   }
 
@@ -52,9 +62,11 @@
   }
 
   .picture {
+    min-width: $housing-card-image-width; // [ipad] if not present, the div width is smaller than the image it contains
+
     img {
-      width: 230px;
-      height: 230px;
+      width: $housing-card-image-width;
+      height: $housing-card-image-width;
     }
   }
 
@@ -69,8 +81,13 @@
       text-align: center;
     }
 
-    @media (min-width: $screen-sm-min) {
-      margin-top: 2em;
+    @media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: $housing-card-image-width;
+      margin-left: 0;
+      text-align: left;
     }
 
     span {
@@ -82,7 +99,11 @@
       background-color: $blue;
 
       @media (max-width: $screen-xs-max) {
-        width: 230px;
+        width: $housing-card-image-width;
+      }
+
+      @media (max-width: $screen-sm-max) {
+        width: $housing-card-image-width;
       }
     }
   }
@@ -126,7 +147,7 @@
   .price {
     span {
       letter-spacing: 0.13em;
-      background-color: $gray-light;
+      background-color: $gray;
     }
   }
 

--- a/apps/web/assets/stylesheets/pages/_home.scss
+++ b/apps/web/assets/stylesheets/pages/_home.scss
@@ -26,6 +26,7 @@
 
     @media (min-width: $screen-sm-min) {
       margin-top: 3em;
+      padding-bottom: 250px;
     }
 
     .title, .explanation {
@@ -60,8 +61,14 @@
   &-footer {
     display: flex;
     justify-content: center;
-    align-items: flex-start; // if not present, the height of the screenshot image is strechted
-    min-height: 250px;
+    align-items: flex-start; // [chrome] if not present, the height of the screenshot image is strechted
+
+    @media (min-width: $screen-sm-min) {
+      position: absolute;
+      bottom: -351.25px;
+      left: 0;
+      right: 0;
+    }
   }
 
   .trip-screenshot {
@@ -70,8 +77,6 @@
     }
 
     @media (min-width: $screen-sm-min) {
-      position: absolute;
-      bottom: -351.25px;
       width: 720px;
       height: 570px;
     }

--- a/apps/web/templates/housings/_housing_card.html.erb
+++ b/apps/web/templates/housings/_housing_card.html.erb
@@ -5,7 +5,7 @@
   <div class="details">
     <div class="description">
       <h2 class="title"><%= housing.title %></h2>
-      <p><%= truncate(housing.description, 130, separator: ' ') %></p>
+      <p><%= truncate(housing.description, 200, separator: ' ') %></p>
       <%= link_to "See on #{housing.provider.capitalize}", housing.url, target: "_blank" %>
     </div>
     <div class="proposer">


### PR DESCRIPTION
The screenshot on the homepage wasn't centered horizontally.

And a long description on a housing was breaking the layout of a housing card. I reworked on the `sm` media query in order to place the price on top of the picture and give more space to the other housing details.